### PR TITLE
Fixed that there is no '__reversed__()' method on dict before py38

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,8 @@ Released: not yet
 
 * Docs: Fixed development status of Pypi package to be Beta.
 
+* Fixed that there is no '__reversed__()' method on dict before Python 3.8.
+
 **Enhancements:**
 
 * Removed dependency to 'six' package.

--- a/immutable_views/_dict_view.py
+++ b/immutable_views/_dict_view.py
@@ -25,6 +25,9 @@ _DICT_SUPPORTS_ITER_VIEW = sys.version_info[0:2] == (2, 7)
 # Indicates Python dict supports the has_key() method
 _DICT_SUPPORTS_HAS_KEY = sys.version_info[0:2] == (2, 7)
 
+# Indicates Python dict supports the __reversed__() method
+_DICT_SUPPORTS_REVERSED = sys.version_info[0:2] >= (3, 8)
+
 # Indicates Python dict supports the __or__/__ror__() methods
 _DICT_SUPPORTS_OR = sys.version_info[0:2] >= (3, 9)
 
@@ -134,6 +137,8 @@ class DictView(Mapping):
         """
         ``reversed(self) ...``:
         Return an iterator through the dictionary in reversed iteration order.
+
+        Added in Python 3.8
 
         The returned iterator yields the items in the underlying dictionary in
         the reversed iteration order.
@@ -505,6 +510,9 @@ if not _DICT_SUPPORTS_ITER_VIEW and not _BUILDING_DOCS:
 
 if not _DICT_SUPPORTS_HAS_KEY and not _BUILDING_DOCS:
     del DictView.has_key
+
+if not _DICT_SUPPORTS_REVERSED and not _BUILDING_DOCS:
+    del DictView.__reversed__
 
 if not _DICT_SUPPORTS_OR and not _BUILDING_DOCS:
     del DictView.__or__

--- a/tests/unittest/test_dict_view.py
+++ b/tests/unittest/test_dict_view.py
@@ -76,6 +76,9 @@ DICT_SUPPORTS_ITER_VIEW = sys.version_info[0:2] == (2, 7)
 # Indicates Python dict supports the has_key() method
 DICT_SUPPORTS_HAS_KEY = sys.version_info[0:2] == (2, 7)
 
+# Indicates Python dict supports the __reversed__() method
+DICT_SUPPORTS_REVERSED = sys.version_info[0:2] >= (3, 8)
+
 # Indicates Python dict supports the __or__/__ror__() methods
 DICT_SUPPORTS_OR = sys.version_info[0:2] >= (3, 9)
 
@@ -790,26 +793,26 @@ TESTCASES_DICTVIEW_REVERSED = [
     (
         "Empty dict",
         dict(
-            obj=DictView(OrderedDict()),
+            obj=DictView({}),
             exp_keys=[],
         ),
-        None, None, True
+        None if DICT_SUPPORTS_REVERSED else TypeError, None, DICT_IS_ORDERED
     ),
     (
         "Dict with one item",
         dict(
-            obj=DictView(OrderedDict([('Dog', 'Cat')])),
+            obj=DictView({'Dog': 'Cat'}),
             exp_keys=['Dog'],
         ),
-        None, None, True
+        None if DICT_SUPPORTS_REVERSED else TypeError, None, DICT_IS_ORDERED
     ),
     (
         "Dict with two items",
         dict(
-            obj=DictView(OrderedDict([('Dog', 'Cat'), ('Budgie', 'Fish')])),
+            obj=DictView({'Dog': 'Cat', 'Budgie': 'Fish'}),
             exp_keys=['Budgie', 'Dog'],
         ),
-        None, None, True
+        None if DICT_SUPPORTS_REVERSED else TypeError, None, DICT_IS_ORDERED
     ),
 ]
 


### PR DESCRIPTION
Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>